### PR TITLE
Hastebin for selected text

### DIFF
--- a/src/main/kotlin/com/vk/admstorm/actions/AdmActionBase.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/AdmActionBase.kt
@@ -22,10 +22,14 @@ abstract class AdmActionBase : AnAction() {
     }
 
     override fun update(e: AnActionEvent) {
+        beforeUpdate(e)
+
         if (e.project == null || !AdmService.getInstance(e.project!!).needBeEnabled()) {
             e.presentation.isEnabledAndVisible = false
         }
     }
+
+    open fun beforeUpdate(e: AnActionEvent) {}
 
     /**
      * Implement this method to provide your action handler.

--- a/src/main/kotlin/com/vk/admstorm/actions/CreateHasteAction.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/CreateHasteAction.kt
@@ -5,28 +5,30 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.fileEditor.impl.LoadTextUtil
 import com.vk.admstorm.notifications.AdmNotification
-import com.vk.admstorm.ui.MessageDialog
 import com.vk.admstorm.utils.MyUtils
 
 class CreateHasteAction : AdmActionBase() {
     override fun actionWithConnectionPerformed(e: AnActionEvent) {
-        val file = e.getData(CommonDataKeys.PSI_FILE)
-        if (file == null) {
-            MessageDialog.showError(
-                "Unable to create a hastebin for the file because it was not found",
-                "File Not Found"
-            )
-            return
-        }
+        val file = e.getRequiredData(CommonDataKeys.PSI_FILE)
+        val editor = e.getRequiredData(CommonDataKeys.EDITOR)
+        val primaryCaret = editor.caretModel.primaryCaret
+        val selectedText = primaryCaret.selectedText
 
-        val text = LoadTextUtil.loadText(file.virtualFile).toString()
+        val copyText = selectedText ?: LoadTextUtil.loadText(file.virtualFile).toString()
 
         ApplicationManager.getApplication().executeOnPooledThread {
-            val link = MyUtils.createHaste(e.project!!, text)
+            val link = MyUtils.createHaste(e.project!!, copyText)
             MyUtils.copyToClipboard(link)
             AdmNotification()
                 .withTitle("Link to hastebin copied to clipboard")
                 .show()
         }
+    }
+
+    override fun beforeUpdate(e: AnActionEvent) {
+        val project = e.project
+        val file = e.getData(CommonDataKeys.PSI_FILE)
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        e.presentation.isEnabledAndVisible = file != null && project != null && editor != null
     }
 }


### PR DESCRIPTION
Now if the `Create Hastebin...` action is called on a non-empty 
selection, a haste will be created with the selected text.

Fixes #7 