### PR TITLE
added the ability to configure automatic push to the server after a commit

### DIFF
--- a/src/main/kotlin/com/vk/admstorm/actions/git/commit/GitCommitAndPushToAdmExecutorAction.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/git/commit/GitCommitAndPushToAdmExecutorAction.kt
@@ -1,4 +1,4 @@
-package com.vk.admstorm.actions.git.checkout
+package com.vk.admstorm.actions.git.commit
 
 import com.intellij.dvcs.commit.getCommitAndPushActionName
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -44,7 +44,7 @@ class GitCommitAndPushToAdmExecutorAction : BaseCommitExecutorAction() {
             val templateText = workflowHandler.getCommitAndPushActionName()
 
             e.presentation.text =
-                templateText.removeSuffix("…") + "→ ${Env.data.serverName.ifEmpty { "server" }} → Gitlab…"
+                templateText.removeSuffix("…") + " → ${Env.data.serverName.ifEmpty { "server" }} → Gitlab…"
         }
 
         super.update(e)

--- a/src/main/kotlin/com/vk/admstorm/actions/git/commit/GitCustomPushCheckinHandlerFactory.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/git/commit/GitCustomPushCheckinHandlerFactory.kt
@@ -1,4 +1,4 @@
-package com.vk.admstorm.actions.git.checkout
+package com.vk.admstorm.actions.git.commit
 
 import com.intellij.openapi.vcs.CheckinProjectPanel
 import com.intellij.openapi.vcs.changes.CommitContext
@@ -8,6 +8,7 @@ import com.vk.admstorm.AdmStormStartupActivity
 import com.vk.admstorm.actions.git.PushToGitlabAction
 import com.vk.admstorm.notifications.AdmNotification
 import com.vk.admstorm.notifications.AdmWarningNotification
+import com.vk.admstorm.settings.AdmStormSettingsState
 import com.vk.admstorm.ssh.SshConnectionService
 
 class GitCustomPushCheckinHandlerFactory : CheckinHandlerFactory() {
@@ -15,6 +16,9 @@ class GitCustomPushCheckinHandlerFactory : CheckinHandlerFactory() {
         return object : CheckinHandler() {
             override fun checkinSuccessful() {
                 if (!commitContext.isPushToGitlabAfterCommit) {
+                    if (AdmStormSettingsState.getInstance().autoPushToServerAfterCommit) {
+                        pushToServer()
+                    }
                     return
                 }
 
@@ -34,6 +38,10 @@ class GitCustomPushCheckinHandlerFactory : CheckinHandlerFactory() {
                 }
 
                 PushToGitlabAction().runAction(panel.project)
+            }
+
+            private fun pushToServer() {
+                PushToGitlabAction.doForcePushOrNotToServerTask(panel.project, force = true)
             }
         }
     }

--- a/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsComponent.form
+++ b/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsComponent.form
@@ -8,7 +8,7 @@
     <properties/>
     <border type="none"/>
     <children>
-      <grid id="638b7" layout-manager="GridLayoutManager" row-count="2" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+      <grid id="638b7" layout-manager="GridLayoutManager" row-count="3" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
         <margin top="0" left="0" bottom="0" right="0"/>
         <constraints>
           <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
@@ -48,6 +48,24 @@
                 </constraints>
                 <properties>
                   <text value="Connect automatically when the project starts"/>
+                </properties>
+              </component>
+            </children>
+          </grid>
+          <grid id="3b202" layout-manager="GridLayoutManager" row-count="1" column-count="1" same-size-horizontally="false" same-size-vertically="false" hgap="-1" vgap="-1">
+            <margin top="0" left="0" bottom="0" right="0"/>
+            <constraints>
+              <grid row="2" column="0" row-span="1" col-span="1" vsize-policy="3" hsize-policy="3" anchor="0" fill="3" indent="0" use-parent-layout="false"/>
+            </constraints>
+            <properties/>
+            <border type="none"/>
+            <children>
+              <component id="a6c5a" class="com.intellij.ui.components.JBCheckBox" binding="myAutoPushToServerAfterCommit">
+                <constraints>
+                  <grid row="0" column="0" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="8" fill="0" indent="0" use-parent-layout="false"/>
+                </constraints>
+                <properties>
+                  <text value="Automatically push to the server after a successful commit"/>
                 </properties>
               </component>
             </children>

--- a/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsComponent.kt
+++ b/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsComponent.kt
@@ -21,6 +21,7 @@ class AdmStormSettingsComponent {
 
     private lateinit var myCheckSyncOnFocusCheckBox: JBCheckBox
     private lateinit var myConnectWhenProjectStartsCheckBox: JBCheckBox
+    private lateinit var myAutoPushToServerAfterCommit: JBCheckBox
 
     private lateinit var myRunPhpLinterAsInTeamcityCheckBox: JBCheckBox
 
@@ -60,6 +61,12 @@ class AdmStormSettingsComponent {
             myConnectWhenProjectStartsCheckBox.isSelected = value
         }
 
+    var autoPushToServerAfterCommit: Boolean
+        get() = myAutoPushToServerAfterCommit.isSelected
+        set(value) {
+            myAutoPushToServerAfterCommit.isSelected = value
+        }
+
     var runPhpLinterAsInTeamcity: Boolean
         get() = myRunPhpLinterAsInTeamcityCheckBox.isSelected
         set(value) {
@@ -77,6 +84,9 @@ class AdmStormSettingsComponent {
         myBranchSyncSettingsPanel.border = IdeBorderFactory.createTitledBorder("Branch synchronization")
         mySyncBranchCheckoutCheckBox.text =
             "Automatically switch branches on ${Env.data.serverName.ifEmpty { "server" }}"
+
+        myAutoPushToServerAfterCommit.text =
+            "Automatically push to the ${Env.data.serverName.ifEmpty { "server" }} after a successful commit"
 
         myPushToGitlabPanel.border = IdeBorderFactory.createTitledBorder("Push to Gitlab")
     }

--- a/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsConfigurable.kt
+++ b/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsConfigurable.kt
@@ -18,7 +18,8 @@ class AdmStormSettingsConfigurable : Configurable {
                 mySettingsComponent.gitConflictResolutionStrategy != settings.gitConflictResolutionStrategy ||
                 mySettingsComponent.checkSyncOnFocus != settings.checkSyncOnFocus ||
                 mySettingsComponent.connectWhenProjectStarts != settings.connectWhenProjectStarts ||
-                mySettingsComponent.runPhpLinterAsInTeamcity != settings.runPhpLinterAsInTeamcityWhenPushToGitlab
+                mySettingsComponent.runPhpLinterAsInTeamcity != settings.runPhpLinterAsInTeamcityWhenPushToGitlab ||
+                mySettingsComponent.autoPushToServerAfterCommit != settings.autoPushToServerAfterCommit
     }
 
     override fun apply() {
@@ -28,6 +29,7 @@ class AdmStormSettingsConfigurable : Configurable {
         settings.checkSyncOnFocus = mySettingsComponent.checkSyncOnFocus
         settings.connectWhenProjectStarts = mySettingsComponent.connectWhenProjectStarts
         settings.runPhpLinterAsInTeamcityWhenPushToGitlab = mySettingsComponent.runPhpLinterAsInTeamcity
+        settings.autoPushToServerAfterCommit = mySettingsComponent.autoPushToServerAfterCommit
     }
 
     override fun reset() {
@@ -37,5 +39,6 @@ class AdmStormSettingsConfigurable : Configurable {
         mySettingsComponent.checkSyncOnFocus = settings.checkSyncOnFocus
         mySettingsComponent.connectWhenProjectStarts = settings.connectWhenProjectStarts
         mySettingsComponent.runPhpLinterAsInTeamcity = settings.runPhpLinterAsInTeamcityWhenPushToGitlab
+        mySettingsComponent.autoPushToServerAfterCommit = settings.autoPushToServerAfterCommit
     }
 }

--- a/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsState.kt
+++ b/src/main/kotlin/com/vk/admstorm/settings/AdmStormSettingsState.kt
@@ -27,6 +27,7 @@ class AdmStormSettingsState : PersistentStateComponent<AdmStormSettingsState?> {
     var checkSyncOnFocus = true
     var connectWhenProjectStarts = true
     var runPhpLinterAsInTeamcityWhenPushToGitlab = false
+    var autoPushToServerAfterCommit = false
 
     override fun getState() = this
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -72,10 +72,10 @@
 
     <executor implementation="com.vk.admstorm.executors.AdmToolsExecutor" id="AdmTools"/>
     <vcs.changes.localCommitExecutor
-      implementation="com.vk.admstorm.actions.git.checkout.GitCommitAndPushToGitlabExecutor"
+      implementation="com.vk.admstorm.actions.git.commit.GitCommitAndPushToGitlabExecutor"
       id="git.commit.and.push.to.gitlab"/>
 
-    <checkinHandlerFactory implementation="com.vk.admstorm.actions.git.checkout.GitCustomPushCheckinHandlerFactory"/>
+    <checkinHandlerFactory implementation="com.vk.admstorm.actions.git.commit.GitCustomPushCheckinHandlerFactory"/>
 
     <notificationGroup id="AdmStorm" displayType="BALLOON"/>
     <notificationGroup id="AdmStorm Important" displayType="STICKY_BALLOON"/>
@@ -96,7 +96,7 @@
     </group>
 
     <action id="git.commit.and.push.adm.executor"
-            class="com.vk.admstorm.actions.git.checkout.GitCommitAndPushToAdmExecutorAction">
+            class="com.vk.admstorm.actions.git.commit.GitCommitAndPushToAdmExecutorAction">
       <add-to-group group-id="Vcs.Commit.PrimaryCommitActions"/>
       <keyboard-shortcut first-keystroke="control alt U" keymap="$default"/>
     </action>


### PR DESCRIPTION
If this is enabled, every time the user creates a commit,
it will automatically push to the development server.

This can reduce the number of manual synchronizations required.

Fixes #18