### PR TITLE
fixed `AlreadyDisposedException`

### DIFF
--- a/src/main/kotlin/com/vk/admstorm/AdmStormStartupActivity.kt
+++ b/src/main/kotlin/com/vk/admstorm/AdmStormStartupActivity.kt
@@ -2,6 +2,8 @@ package com.vk.admstorm
 
 import com.intellij.openapi.application.ApplicationActivationListener
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.EditorFactory
 import com.intellij.openapi.editor.ex.EditorEventMulticasterEx
@@ -11,7 +13,9 @@ import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.startup.StartupActivity
 import com.intellij.openapi.wm.IdeFrame
+import com.intellij.serviceContainer.AlreadyDisposedException
 import com.intellij.ssh.SshTransportException
+import com.intellij.util.messages.MessageBusConnection
 import com.vk.admstorm.env.Env
 import com.vk.admstorm.git.sync.SyncChecker
 import com.vk.admstorm.highlight.CppTypeHighlightPatcher
@@ -24,141 +28,160 @@ import com.vk.admstorm.utils.MyUtils.measureTime
 import com.vk.admstorm.utils.MyUtils.runBackground
 import java.util.concurrent.atomic.AtomicBoolean
 
+@Service
 class AdmStormStartupActivity : StartupActivity {
     companion object {
         private val LOG = Logger.getInstance(AdmStormStartupActivity::class.java)
 
-        private var myFocusListenerIsSet = false
-        private val myCheckSyncRunning = AtomicBoolean(false)
+        private var myConnection: MessageBusConnection? = null
 
-        private fun checkSyncSilently(project: Project) {
-            myCheckSyncRunning.set(true)
+        fun getInstance(project: Project) = project.service<AdmStormStartupActivity>()
+    }
 
-            runBackground(project, "AdmStorm: Check sync with ${Env.data.serverName}") {
+    private var myFocusListenerIsSet = false
+    private val myCheckSyncRunning = AtomicBoolean(false)
+
+    private fun checkSyncSilently(project: Project) {
+        myCheckSyncRunning.set(true)
+
+        runBackground(project, "AdmStorm: Check sync with ${Env.data.serverName}") {
+            try {
+                val state = SyncChecker.getInstance(project).currentState()
+                if (state == SyncChecker.State.Unknown) {
+                    LOG.warn("No SSH connection")
+                    return@runBackground
+                }
+
+                if (state == SyncChecker.State.Ok) {
+                    return@runBackground
+                }
+
+                val subject = when (state) {
+                    SyncChecker.State.BranchNotSync -> "branch"
+                    SyncChecker.State.LastCommitNotSync -> "last commit"
+                    SyncChecker.State.FilesNotSync -> "files"
+                    else -> "repository"
+                }
+
+                AdmWarningNotification("", true)
+                    .withTitle("Local $subject not sync with ${Env.data.serverName}")
+                    .withActions(
+                        AdmNotification.Action("Show details") { _, notification ->
+                            notification.expire()
+                            SyncChecker.getInstance(project).doCheckSyncSilentlyTask(null) {
+                                AdmNotification()
+                                    .withTitle("Local and ${Env.data.serverName} have been synced successfully")
+                                    .show()
+                            }
+                        }
+                    )
+                    .show()
+
+            } finally {
+                myCheckSyncRunning.set(false)
+            }
+        }
+    }
+
+    fun afterConnectionTasks(project: Project, onReady: Runnable? = null) {
+        ProgressManager.getInstance().run(object : BackgroundableTask(
+            project,
+            "AdmStorm: Resolve env data",
+        ) {
+            override fun run() {
+                myIndicator.isIndeterminate = false
+                myIndicator.fraction = 0.05
+
                 try {
-                    val state = SyncChecker.getInstance(project).currentState()
-                    if (state == SyncChecker.State.Unknown) {
-                        LOG.warn("No SSH connection")
-                        return@runBackground
-                    }
-
-                    if (state == SyncChecker.State.Ok) {
-                        return@runBackground
-                    }
-
-                    val subject = when (state) {
-                        SyncChecker.State.BranchNotSync -> "branch"
-                        SyncChecker.State.LastCommitNotSync -> "last commit"
-                        SyncChecker.State.FilesNotSync -> "files"
-                        else -> "repository"
-                    }
-
-                    AdmWarningNotification("", true)
-                        .withTitle("Local $subject not sync with ${Env.data.serverName}")
-                        .withActions(
-                            AdmNotification.Action("Show details") { _, notification ->
-                                notification.expire()
-                                SyncChecker.getInstance(project).doCheckSyncSilentlyTask(null) {
-                                    AdmNotification()
-                                        .withTitle("Local and ${Env.data.serverName} have been synced successfully")
-                                        .show()
-                                }
-                            }
-                        )
-                        .show()
-
-                } finally {
-                    myCheckSyncRunning.set(false)
-                }
-            }
-        }
-
-        fun afterConnectionTasks(project: Project, onReady: Runnable? = null) {
-            ProgressManager.getInstance().run(object : BackgroundableTask(
-                project,
-                "AdmStorm: Resolve env data",
-            ) {
-                override fun run() {
-                    myIndicator.isIndeterminate = false
-                    myIndicator.fraction = 0.05
-
-                    try {
-                        step(0.7) {
-                            measureTime(LOG, "resolve env data") {
-                                Env.resolve(project)
-                            }
+                    step(0.7) {
+                        measureTime(LOG, "resolve env data") {
+                            Env.resolve(project)
                         }
+                    }
 
-                        step("AdmStorm: Resolve root", 0.8) {
-                            measureTime(LOG, "resolve root") {
-                                MyPathUtils.resolveRemoteRoot(project)
-                            }
+                    step("AdmStorm: Resolve root", 0.8) {
+                        measureTime(LOG, "resolve root") {
+                            MyPathUtils.resolveRemoteRoot(project)
                         }
-
-                        step(1.0) {
-                            checkSyncSilently(project)
-                            setListenerForEditorsFocus(project)
-                        }
-
-                        onReady?.run()
-                    } catch (e: SshTransportException) {
-                        LOG.warn("Unexpected exception while afterConnectionTasks", e)
-                    }
-                }
-            })
-        }
-
-        /**
-         * Sets up a listener that every time the IDE has focus, it starts
-         * sync checking in the background.
-         *
-         * This can be useful if some changes were made on the server through
-         * the console, and then the user switched to the IDE, thanks to this
-         * listener, the user will be immediately shown a notification with a
-         * quick action for synchronization.
-         *
-         * This behavior can be disabled in the settings.
-         */
-        private fun setListenerForEditorsFocus(project: Project) {
-            if (myFocusListenerIsSet) {
-                LOG.info("IDE focus listener is already installed")
-                return
-            }
-
-            if (EditorFactory.getInstance().eventMulticaster !is EditorEventMulticasterEx) {
-                LOG.warn("'EditorFactory.getInstance().eventMulticaster' is not EditorEventMulticasterEx")
-                return
-            }
-
-            val connection = ApplicationManager.getApplication().messageBus.connect()
-            connection.subscribe(ApplicationActivationListener.TOPIC, object : ApplicationActivationListener {
-                override fun applicationActivated(ideFrame: IdeFrame) {
-                    LOG.info("Application activated")
-
-                    if (!AdmStormSettingsState.getInstance().checkSyncOnFocus) {
-                        LOG.info("Check has not started because it was disabled")
-                        return
                     }
 
-                    if (!SshConnectionService.getInstance(project).isConnected()) {
-                        LOG.info("Check has not started because there is no SSH connection")
-                        return
-                    }
-
-                    if (!myCheckSyncRunning.get()) {
-                        LOG.info("Start check sync silently")
-
+                    step(1.0) {
                         checkSyncSilently(project)
-                    } else {
-                        LOG.info("Check has not started because the previous check has not finished yet")
+                        setListenerForEditorsFocus(project)
                     }
+
+                    onReady?.run()
+                } catch (e: SshTransportException) {
+                    LOG.warn("Unexpected exception while afterConnectionTasks", e)
+                }
+            }
+        })
+    }
+
+    /**
+     * Sets up a listener that every time the IDE has focus, it starts
+     * sync checking in the background.
+     *
+     * This can be useful if some changes were made on the server through
+     * the console, and then the user switched to the IDE, thanks to this
+     * listener, the user will be immediately shown a notification with a
+     * quick action for synchronization.
+     *
+     * This behavior can be disabled in the settings.
+     *
+     * Note:
+     * Since the listener is per-application but project-specific, we needed
+     * to disconnect the connection every time the project is closed to create
+     * a new connection with the new project, otherwise we would get
+     * AlreadyDisposedException.
+     */
+    private fun setListenerForEditorsFocus(project: Project) {
+        if (myConnection != null) {
+            LOG.info("IDE focus listener is already installed for '${project.name}'")
+            return
+        }
+
+        if (EditorFactory.getInstance().eventMulticaster !is EditorEventMulticasterEx) {
+            LOG.warn("'EditorFactory.getInstance().eventMulticaster' is not EditorEventMulticasterEx")
+            return
+        }
+
+        myConnection = ApplicationManager.getApplication().messageBus.connect()
+        myConnection?.subscribe(ApplicationActivationListener.TOPIC, object : ApplicationActivationListener {
+            override fun applicationActivated(ideFrame: IdeFrame) {
+                LOG.info("Application activated")
+
+                if (!AdmStormSettingsState.getInstance().checkSyncOnFocus) {
+                    LOG.info("Check has not started because it was disabled")
+                    return
                 }
 
-                override fun applicationDeactivated(ideFrame: IdeFrame) = LOG.info("Application deactivated")
-            })
+                val connectionService = try {
+                    SshConnectionService.getInstance(project)
+                } catch (e: AlreadyDisposedException) {
+                    LOG.info("Check has not started because project already disposed, disconnect")
+                    myConnection?.disconnect()
+                    myConnection = null
+                    return
+                }
 
-            myFocusListenerIsSet = true
-        }
+                if (!connectionService.isConnected()) {
+                    LOG.info("Check has not started because there is no SSH connection")
+                    return
+                }
+
+                if (!myCheckSyncRunning.get()) {
+                    LOG.info("Start check sync silently")
+                    checkSyncSilently(project)
+                } else {
+                    LOG.info("Check has not started because the previous check has not finished yet")
+                }
+            }
+
+            override fun applicationDeactivated(ideFrame: IdeFrame) = LOG.info("Application deactivated")
+        })
+
+        myFocusListenerIsSet = true
     }
 
     override fun runActivity(project: Project) {
@@ -177,17 +200,5 @@ class AdmStormStartupActivity : StartupActivity {
                 afterConnectionTasks(project)
             }
         }
-
-        // TODO: do we need to delete files on the server when deleting them locally?
-//        val connection = project.messageBus.connect()
-//        connection.subscribe(VirtualFileManager.VFS_CHANGES, object : BulkFileListener {
-//            override fun after(events: MutableList<out VFileEvent>) {
-//                events.forEach {
-//                    if (it is VFileDeleteEvent) {
-//
-//                    }
-//                }
-//            }
-//        })
     }
 }

--- a/src/main/kotlin/com/vk/admstorm/actions/ConnectToAdmViaSshAction.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/ConnectToAdmViaSshAction.kt
@@ -9,7 +9,7 @@ import com.vk.admstorm.ssh.SshConnectionService
 class ConnectToAdmViaSshAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         SshConnectionService.getInstance(e.project!!).connect {
-            AdmStormStartupActivity.afterConnectionTasks(e.project!!)
+            AdmStormStartupActivity.getInstance(e.project!!).afterConnectionTasks(e.project!!)
         }
     }
 

--- a/src/main/kotlin/com/vk/admstorm/actions/git/commit/GitCustomPushCheckinHandlerFactory.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/git/commit/GitCustomPushCheckinHandlerFactory.kt
@@ -29,7 +29,7 @@ class GitCustomPushCheckinHandlerFactory : CheckinHandlerFactory() {
                             AdmNotification.Action("Connect...") { e, notification ->
                                 notification.expire()
                                 SshConnectionService.getInstance(panel.project).connect {
-                                    AdmStormStartupActivity.afterConnectionTasks(e.project!!)
+                                    AdmStormStartupActivity.getInstance(panel.project).afterConnectionTasks(e.project!!)
                                 }
                             }
                         )

--- a/src/main/kotlin/com/vk/admstorm/git/AdmBranchContextTracker.kt
+++ b/src/main/kotlin/com/vk/admstorm/git/AdmBranchContextTracker.kt
@@ -50,7 +50,7 @@ class AdmBranchContextTracker(private var myProject: Project) : BranchChangeList
                     notification.expire()
 
                     SshConnectionService.getInstance(myProject).connect {
-                        AdmStormStartupActivity.afterConnectionTasks(myProject) {
+                        AdmStormStartupActivity.getInstance(myProject).afterConnectionTasks(myProject) {
                             RemoteBranchSwitcher(myProject, onGitConflictCanceled)
                                 .switch(branchName, false)
                         }

--- a/src/main/kotlin/com/vk/admstorm/playground/KphpPlaygroundWindow.kt
+++ b/src/main/kotlin/com/vk/admstorm/playground/KphpPlaygroundWindow.kt
@@ -318,5 +318,9 @@ require_once "vendor/autoload.php";
         if (!myEditor.isDisposed) {
             EditorFactory.getInstance().releaseEditor(myEditor)
         }
+
+        if (!myDiffViewer.isDisposed) {
+            myDiffViewer.dispose()
+        }
     }
 }

--- a/src/main/kotlin/com/vk/admstorm/ssh/SshConnectionService.kt
+++ b/src/main/kotlin/com/vk/admstorm/ssh/SshConnectionService.kt
@@ -89,7 +89,7 @@ class SshConnectionService(private var myProject: Project) : Disposable {
                 AdmNotification.Action("Connect...") { e, notification ->
                     notification.expire()
                     connect {
-                        AdmStormStartupActivity.afterConnectionTasks(e.project!!)
+                        AdmStormStartupActivity.getInstance(myProject).afterConnectionTasks(e.project!!)
                     }
                 }
             )

--- a/src/main/kotlin/com/vk/admstorm/transfer/TransferService.kt
+++ b/src/main/kotlin/com/vk/admstorm/transfer/TransferService.kt
@@ -346,7 +346,7 @@ class TransferService(private var myProject: Project) {
                 AdmNotification.Action("Connect...") { e, notification ->
                     notification.expire()
                     SshConnectionService.getInstance(e.project!!).connect {
-                        AdmStormStartupActivity.afterConnectionTasks(e.project!!)
+                        AdmStormStartupActivity.getInstance(e.project!!).afterConnectionTasks(e.project!!)
                     }
                 }
             )

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -46,6 +46,7 @@
     <projectService serviceImplementation="com.vk.admstorm.ssh.SshConnectionService"/>
     <projectService serviceImplementation="com.vk.admstorm.transfer.TransferService"/>
     <projectService serviceImplementation="com.vk.admstorm.git.sync.SyncChecker"/>
+    <projectService serviceImplementation="com.vk.admstorm.AdmStormStartupActivity"/>
 
     <!-- KPHP Benchmarks Configuration -->
     <configurationType implementation="com.vk.admstorm.configuration.kbench.KBenchConfigurationType"/>


### PR DESCRIPTION
Since the `ApplicationActivationListener` listener is
per-application but project-specific, we needed to
disconnect the connection every time the project is
closed to create a new connection with the new project,
otherwise we would get `AlreadyDisposedException`.

Fixes #23 