### PR TITLE
number of commits that are shown during synchronization is reduced to 30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@
   - Checking the name of the benchmark class
 - Yarn Watch support
 
+### Other improvements
+
+- Number of commits that are shown during synchronization is reduced to 30
+  Now if more than 30 commits require synchronization, then only the first 30 and the ellipsis at the end will be shown.
+
 ### Changed
 
 - Now, when resetting the yubikey, the "Remember" checkbox will be selected by default in the yubikey password reset

--- a/src/main/kotlin/com/vk/admstorm/actions/git/PushOptionsDialog.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/git/PushOptionsDialog.kt
@@ -78,7 +78,7 @@ class PushOptionsDialog(
             ServerRepoTreeNode(branchName, !exists)
         }
 
-        myPushCommitsPanel = PushCommitsPanel(project, commits, commitBuilder, rootNodeBuilder)
+        myPushCommitsPanel = PushCommitsPanel(project, commits, commits.size, commitBuilder, rootNodeBuilder)
 
         myPushActions.add(object : AbstractAction("Push") {
             override fun actionPerformed(e: ActionEvent?) {

--- a/src/main/kotlin/com/vk/admstorm/actions/git/panels/ShowMoreCommitsNode.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/git/panels/ShowMoreCommitsNode.kt
@@ -1,0 +1,18 @@
+package com.vk.admstorm.actions.git.panels
+
+import com.intellij.dvcs.push.ui.PushLogTreeUtil
+import com.intellij.dvcs.push.ui.TooltipNode
+import com.intellij.ui.ColoredTreeCellRenderer
+import com.intellij.ui.SimpleTextAttributes
+
+open class ShowMoreCommitsNode(private val remainCount: Int) : TreeBaseNode(), TooltipNode {
+    override fun render(renderer: ColoredTreeCellRenderer) {
+        val repositoryDetailsTextAttributes =
+            PushLogTreeUtil.addTransparencyIfNeeded(renderer, SimpleTextAttributes.REGULAR_ATTRIBUTES, isChecked())
+        renderer.append("...", repositoryDetailsTextAttributes)
+    }
+
+    override fun getTooltip(): String {
+        return "Not shown commits ($remainCount)"
+    }
+}

--- a/src/main/kotlin/com/vk/admstorm/git/sync/commits/GitCommitComparison.kt
+++ b/src/main/kotlin/com/vk/admstorm/git/sync/commits/GitCommitComparison.kt
@@ -27,9 +27,9 @@ class GitCommitComparison(
             return
         }
 
-        val commitsBetween = GitUtils.localCommitsInRange(myProject, remoteCommit, localCommit)
+        val (commitsBetween, countBetween) = GitUtils.localCommitsInRange(myProject, remoteCommit, localCommit)
 
-        showDialog(localCommit, remoteCommit, commitsBetween, true)
+        showDialog(localCommit, remoteCommit, commitsBetween, countBetween, true)
     }
 
     private fun localCommitBeforeRemote(localCommit: Commit, remoteCommit: Commit, distance: Int) {
@@ -38,15 +38,16 @@ class GitCommitComparison(
             return
         }
 
-        val commitsBetween = GitUtils.remoteCommitsInRange(myProject, localCommit, remoteCommit)
+        val (commitsBetween, countBetween) = GitUtils.remoteCommitsInRange(myProject, localCommit, remoteCommit)
 
-        showDialog(localCommit, remoteCommit, commitsBetween, false)
+        showDialog(localCommit, remoteCommit, commitsBetween, countBetween, false)
     }
 
     private fun showDialog(
         localCommit: Commit,
         remoteCommit: Commit,
         commitsBetween: List<Commit>,
+        countBetween: Int,
         needPushToServer: Boolean,
     ) {
         ApplicationManager.getApplication().invokeLater {
@@ -56,6 +57,7 @@ class GitCommitComparison(
                     localCommit,
                     remoteCommit,
                     commitsBetween,
+                    countBetween,
                     needPushToServer,
                     myOnSync
                 )

--- a/src/main/kotlin/com/vk/admstorm/git/sync/commits/NotSyncCommitsDialog.kt
+++ b/src/main/kotlin/com/vk/admstorm/git/sync/commits/NotSyncCommitsDialog.kt
@@ -26,7 +26,8 @@ class NotSyncCommitsDialog(
     private val myProject: Project,
     localCommit: Commit,
     remoteCommit: Commit,
-    private val myBetweenCommits: List<Commit>,
+    myBetweenCommits: List<Commit>,
+    private val myCountBetween: Int,
     private val myNeedPushToServer: Boolean = false,
 ) : DialogWrapper(myProject, true) {
 
@@ -39,7 +40,8 @@ class NotSyncCommitsDialog(
         private const val CENTER_PANEL_WIDTH = 800
 
         fun show(
-            project: Project, localCommit: Commit, remoteCommit: Commit, myBetweenCommits: List<Commit>,
+            project: Project, localCommit: Commit, remoteCommit: Commit,
+            myBetweenCommits: List<Commit>, countBetween: Int,
             needPushToServer: Boolean = false,
             onSyncFinish: Runnable? = null,
         ): Choice {
@@ -48,6 +50,7 @@ class NotSyncCommitsDialog(
                 localCommit,
                 remoteCommit,
                 myBetweenCommits,
+                countBetween,
                 needPushToServer,
             )
 
@@ -95,13 +98,13 @@ class NotSyncCommitsDialog(
     private fun createMessageTextPane(): JTextPane {
         val messageText = if (myNeedPushToServer)
             """<html>
-            There are <b>${myBetweenCommits.size} commits</b> in <b>local</b> branch 
+            There are <b>$myCountBetween commits</b> in <b>local</b> branch 
             that were not pushed to <b>${ServerNameProvider.name()}</b> branch
             </html>
             """.trimIndent()
         else
             """<html>
-            There are <b>${myBetweenCommits.size} commits</b> in <b>${ServerNameProvider.name()}</b> branch 
+            There are <b>$myCountBetween commits</b> in <b>${ServerNameProvider.name()}</b> branch 
             that were not fetched to <b>local</b> branch
             </html>
             """.trimIndent()
@@ -165,7 +168,7 @@ class NotSyncCommitsDialog(
             commits.add(localCommit)
         }
 
-        myPushCommitsPanel = PushCommitsPanel(myProject, commits, commitBuilder, rootBuilder)
+        myPushCommitsPanel = PushCommitsPanel(myProject, commits, myCountBetween, commitBuilder, rootBuilder)
 
         okAction.putValue(Action.SHORT_DESCRIPTION, "Sync all changes")
         cancelAction.putValue(Action.SHORT_DESCRIPTION, "Don't sync")


### PR DESCRIPTION
Now if more than 30 commits require synchronization, then only the first
30 and the ellipsis at the end will be shown.

This should improve UX, as it will greatly reduce the wait time after a
rebase, when the difference can be thousands of commits.

Fixes #35 