### PR TITLE
removed unnecessary logging when it wasn't possible to find a group

### DIFF
--- a/src/main/kotlin/com/vk/admstorm/actions/git/listeners/PatternBasedProgressListener.kt
+++ b/src/main/kotlin/com/vk/admstorm/actions/git/listeners/PatternBasedProgressListener.kt
@@ -45,7 +45,6 @@ abstract class PatternBasedProgressListener(protected val myIndicator: ProgressI
     protected fun getGroup(matcher: Matcher, groupName: String): String? = try {
         matcher.group(groupName)
     } catch (e: Exception) {
-        LOG.warn("Failed to get group $groupName", e)
         null
     }
 


### PR DESCRIPTION
in a regular expression, as this isn't an error and is expected behavior for some lines